### PR TITLE
Load `zstd` with pkg-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ name = "hello-rust"
 version = "0.1.0"
 dependencies = [
  "zstd",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -32,6 +33,12 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "zstd"
@@ -60,4 +67,5 @@ checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zstd = "0.12.1"
+zstd = { version = "0.12.1", features = ["pkg-config"] }

--- a/pkgs/hello-rust/default.nix
+++ b/pkgs/hello-rust/default.nix
@@ -8,6 +8,7 @@
   pkg-config,
   libiconv,
   darwin,
+  zstd,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "hello-rust";
@@ -26,14 +27,13 @@ rustPlatform.buildRustPackage rec {
     };
   };
 
-
-
-  # Non-Rust runtime dependencies (most likely libraries) of your project can 
+  # Non-Rust runtime dependencies (most likely libraries) of your project can
   # be added in buildInputs.
   # Make sure to import any additional dependencies above
   buildInputs =
     [
       openssl.dev
+      zstd
     ]
     # Platform specific dependencies can be added as well
     # For MacOS


### PR DESCRIPTION
As Nix aims to be the single source of dependencies, all Cargo dependencies are bundled and provided as _read only_ vendored sources [1]. Without the (optional) `pkg-config` feature, `zstd-sys` is configured to build the `zstd` library from source as part of its own build process [2]. However, `zstd-sys` is located in a read only directory, so when its build script tries to copy  files [3], this step fails with a `Permission Denied` error.

relevant excerpt from the build log:

     >   thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }', /private/tmp/nix-build-hello-rust-0.0.0.drv-0/cargo-vendor-dir/zstd-sys-2.0.4+zstd.1.5.2/build.rs:211:58

The solution (for this crate) is to enable the `pkg-config` feature, which will employ `pkg-config` to link the rust wrapper to a pre-built `zstd`. Since now nix needs to supply `zstd`,
we have to add it as an import in the nix package definition.

[1]: https://doc.rust-lang.org/cargo/reference/source-replacement.html
[2]: https://github.com/gyscos/zstd-rs/blob/90d080e2d296d6dd09336a041958340e118fe436/zstd-safe/zstd-sys/build.rs#L234
[3]: https://github.com/gyscos/zstd-rs/blob/90d080e2d296d6dd09336a041958340e118fe436/zstd-safe/zstd-sys/build.rs#L205-L210